### PR TITLE
Updates to eLife file names and locations

### DIFF
--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -217,12 +217,14 @@ ElifeConverter.Prototype = function() {
 
     var pdfURI = article.querySelector("self-uri[content-type=pdf]");
 
-    var pdfLink = [
-      "http://publishing-cdn.elifesciences.org/",
-      state.doc.id,
-      "/",
-      pdfURI ? pdfURI.getAttribute("xlink:href") : "#"
-    ].join('');
+    if (pdfURI) {
+      var pdfLink = [
+        "http://publishing-cdn.elifesciences.org/",
+        state.doc.id,
+        "/",
+        pdfURI ? pdfURI.getAttribute("xlink:href") : "#"
+      ].join('');
+    }
     
     // Version number from the PDF href, default to 1
     var match = null;

--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -128,12 +128,19 @@ ElifeConverter.Prototype = function() {
       return [baseURL, url].join('');
     } else {
       // Use special URL resolving for production articles
+
+      // File extension support
+      if (url.match(/\.tif$/g)) {
+        url = url.replace(/\.tif$/g, '.jpg')
+      } else if (!(url.match(/\.gif$/g))) {
+        url = url+'.jpg'
+      }
+      
       return [
-        "http://cdn.elifesciences.org/elife-articles/",
+        "http://publishing-cdn.elifesciences.org/",
         state.doc.id,
-        "/jpg/",
-        url,
-        ".jpg"
+        "/",
+        url
       ].join('');
     }
   };
@@ -144,9 +151,9 @@ ElifeConverter.Prototype = function() {
       return [baseURL, node.url].join('');
     } else {
       node.url = [
-        "http://cdn.elifesciences.org/elife-articles/",
+        "http://publishing-cdn.elifesciences.org/",
         state.doc.id,
-        "/suppl/",
+        "/",
         node.url
       ].join('');
     }
@@ -211,9 +218,9 @@ ElifeConverter.Prototype = function() {
     var pdfURI = article.querySelector("self-uri[content-type=pdf]");
 
     var pdfLink = [
-      "http://cdn.elifesciences.org/elife-articles/",
+      "http://publishing-cdn.elifesciences.org/",
       state.doc.id,
-      "/pdf/",
+      "/",
       pdfURI ? pdfURI.getAttribute("xlink:href") : "#"
     ].join('');
 
@@ -259,9 +266,9 @@ ElifeConverter.Prototype = function() {
       return [baseURL, node.url].join('');
     } else {
       node.url = [
-        "http://cdn.elifesciences.org/elife-articles/",
+        "http://publishing-cdn.elifesciences.org/",
         state.doc.id,
-        "/suppl/",
+        "/",
         node.url
       ].join('');
     }
@@ -288,12 +295,19 @@ ElifeConverter.Prototype = function() {
       return [baseURL, url].join('');
     } else {
       // Use special URL resolving for production articles
+      
+      // File extension support
+      if (url.match(/\.tif$/g)) {
+        url = url.replace(/\.tif$/g, '.jpg')
+      } else if (!(url.match(/\.gif$/g))) {
+        url = url+'.jpg'
+      }
+      
       return [
-        "http://cdn.elifesciences.org/elife-articles/",
+        "http://publishing-cdn.elifesciences.org/",
         state.doc.id,
-        "/jpg/",
-        url,
-        ".jpg"
+        "/",
+        url
       ].join('');
     }
   };

--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -223,6 +223,13 @@ ElifeConverter.Prototype = function() {
       "/",
       pdfURI ? pdfURI.getAttribute("xlink:href") : "#"
     ].join('');
+    
+    // Version number from the PDF href, default to 1
+    var match = null;
+    if (pdfURI) {
+      match = pdfURI.getAttribute("xlink:href").match(/\w*-\w*-v(\d*).pdf$/);
+    }
+    var version = match ? match[1] : 1;
 
     // Collect Links
     // ---------------
@@ -238,7 +245,7 @@ ElifeConverter.Prototype = function() {
     }
 
     links.push({
-      url: "https://s3.amazonaws.com/elife-cdn/elife-articles/"+state.doc.id+"/elife"+state.doc.id+".xml",
+      url: "https://s3.amazonaws.com/elife-publishing-cdn/"+state.doc.id+"/elife-"+state.doc.id+"-v"+version+".xml",
       name: "Source XML",
       type: "xml"
     });


### PR DESCRIPTION
eLife file naming has changed to include article version numbers, and article assets have moved to a different URL.

Code changes are,

- support for optional ".tif" file extension on graphics
- optional ".gif" file extension on graphics, for animated gifs
- change URLs of all assets
- change URL of the XML file link, which gets a "hint" of the article version number from the PDF file name
- for articles with no PDF, a version number of 1 is used as a default (which should be correct most of the time)
- optionally print the PDF link (correction articles do not have a PDF)


