### PR TITLE
Use HTTPS where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **Lens** provides a novel way of looking at content on the web. It is designed to make life easier for researchers, reviewers, authors and readers.
 
-- **Read the [announcement](http://elifesciences.org/elife-news/lens)**
-- **Watch the [introduction video](http://vimeo.com/67254579).**
-- **See Lens in [action](http://lens.elifesciences.org/00778)**
+- **Read the [announcement](https://elifesciences.org/elife-news/lens)**
+- **Watch the [introduction video](https://vimeo.com/67254579).**
+- **See Lens in [action](https://lens.elifesciences.org/00778)**
 
 ## Using Lens
 
@@ -94,7 +94,7 @@ ElifeConverter.Prototype = function() {
       return [baseURL, node.url].join('');
     } else {
       node.url = [
-        "http://cdn.elifesciences.org/elife-articles/",
+        "https://cdn.elifesciences.org/elife-articles/",
         state.doc.id,
         "/suppl/",
         node.url
@@ -203,7 +203,7 @@ Lens can easily be extended with a customized panel. It can be used to show addi
 - Pull in metrics (click count, number of articles citing that article etc.)
 - Retrieve related articles dynamically (e.g. important ones that reference the existing one)
 
-For demonstration we will look at the implementation of a simple Altmetrics panel. It will pull data asynchronously from the Altmetrics API (http://api.altmetric.com/v1/doi/10.7554/eLife.00005) and render the information in Lens.
+For demonstration we will look at the implementation of a simple Altmetrics panel. It will pull data asynchronously from the Altmetrics API (https://api.altmetric.com/v1/doi/10.7554/eLife.00005) and render the information in Lens.
 
 #### Panel Definition
 
@@ -241,7 +241,7 @@ AltmetricsController.Prototype = function() {
     var doi = this.document.get('publication_info').doi;
 
     $.ajax({
-      url: "http://api.altmetric.com/v1/doi/"+doi,
+      url: "https://api.altmetric.com/v1/doi/"+doi,
       dataType: "json",
     }).done(function(res) {
       cb(null, res);
@@ -335,9 +335,9 @@ Mobile support has been removed with Lens 2.0 to reduce technical debt and itera
 
 ## Credits
 
-Lens was developed in collaboration between [UC Berkeley](http://bioegrad.berkeley.edu/) graduate student [Ivan Grubisic](http://www.linkedin.com/pub/ivan-grubisic/26/353/739) and [eLife](http://elifesciences.org). The team of [Substance](http://substance.io) is helping with the technical execution.
+Lens was developed in collaboration between [UC Berkeley](http://bioegrad.berkeley.edu/) graduate student [Ivan Grubisic](https://www.linkedin.com/pub/ivan-grubisic/26/353/739) and [eLife](https://elifesciences.org). The team of [Substance](http://substance.io) is helping with the technical execution.
 
-Substantial contributions were made by [HighWire](highwire.org), which launched Lens for a number of science journals in fall 2014 (The Journal of Biological Chemistry, The Plant Cell, Journal of Lipid Research, mBio®, and more). [The American Mathematical Society (AMS)](http://ams.org/) made Lens ready for advanced rendering of math articles.
+Substantial contributions were made by [HighWire](http://highwire.org), which launched Lens for a number of science journals in fall 2014 (The Journal of Biological Chemistry, The Plant Cell, Journal of Lipid Research, mBio®, and more). [The American Mathematical Society (AMS)](http://ams.org/) made Lens ready for advanced rendering of math articles.
 
 Thanks go to the following people, who made Lens possible:
 

--- a/article/README.md
+++ b/article/README.md
@@ -1,7 +1,7 @@
 Lens Article
 =====
 
-The Lens Article Format is an implementation the [Substance Document Model](http://github.com/substance/document) dedicated to scientific content. It features basic content types such as paragraphs, headings, and various figure types such as images, tables and videos complete with captions and cross-references.
+The Lens Article Format is an implementation the [Substance Document Model](https://github.com/substance/document) dedicated to scientific content. It features basic content types such as paragraphs, headings, and various figure types such as images, tables and videos complete with captions and cross-references.
 
 The document defintions can be extended easily, so you can either create your own flavour or contribute to the Lens Article Format directly.
 
@@ -9,4 +9,4 @@ The document defintions can be extended easily, so you can either create your ow
 
 - XML-based formats such as NML are hard to consume by webclients
 - Strict separation of content and style. Existing formats target print, and thus contain style information, which makes them hard to process by computer programs
-- The greatest advantage of Lens Articles is that any of them can be viewed in [Lens](http://github.com/elifesciences/lens), a modern web-based interface for consuming science content.
+- The greatest advantage of Lens Articles is that any of them can be viewed in [Lens](https://github.com/elifesciences/lens), a modern web-based interface for consuming science content.

--- a/article/nodes/citation/citation.js
+++ b/article/nodes/citation/citation.js
@@ -90,7 +90,7 @@ Citation.example = {
   "citation_urls": [
     {
       "name": "PubMed",
-      "url": "http://www.ncbi.nlm.nih.gov/pubmed/19606141"
+      "url": "https://www.ncbi.nlm.nih.gov/pubmed/19606141"
     }
   ]
 };

--- a/article/nodes/video/video.js
+++ b/article/nodes/video/video.js
@@ -58,10 +58,10 @@ Video.example = {
   "id": "video_1",
   "type": "video",
   "label": "Video 1.",
-  "url": "http://cdn.elifesciences.org/video/eLifeLensIntro2.mp4",
-  "url_webm": "http://cdn.elifesciences.org/video/eLifeLensIntro2.webm",
-  "url_ogv": "http://cdn.elifesciences.org/video/eLifeLensIntro2.ogv",
-  "poster": "http://cdn.elifesciences.org/video/eLifeLensIntro2.png",
+  "url": "https://cdn.elifesciences.org/video/eLifeLensIntro2.mp4",
+  "url_webm": "https://cdn.elifesciences.org/video/eLifeLensIntro2.webm",
+  "url_ogv": "https://cdn.elifesciences.org/video/eLifeLensIntro2.ogv",
+  "poster": "https://cdn.elifesciences.org/video/eLifeLensIntro2.png",
   // "doi": "http://dx.doi.org/10.7554/Fake.doi.003",
   "caption": "caption_25"
 };

--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -98,11 +98,11 @@ ElifeConverter.Prototype = function() {
     }
 
     node.breadcrumbs = [
-      { name: "eLife", url: "http://elifesciences.org/", image: "http://lens.elifesciences.org/lens-elife/styles/elife.png" },
-      { name: dispChannel, url: "http://elifesciences.org/category/"+dispChannel.replace(/ /g, '-').toLowerCase() },
+      { name: "eLife", url: "https://elifesciences.org/", image: "https://lens.elifesciences.org/lens-elife/styles/elife.png" },
+      { name: dispChannel, url: "https://elifesciences.org/category/"+dispChannel.replace(/ /g, '-').toLowerCase() },
     ];
 
-    if (category) node.breadcrumbs.push( { name: category, url: "http://elifesciences.org/category/"+category.replace(/ /g, '-').toLowerCase() } );
+    if (category) node.breadcrumbs.push( { name: category, url: "https://elifesciences.org/category/"+category.replace(/ /g, '-').toLowerCase() } );
   };
 
   // Resolves figure url
@@ -116,7 +116,7 @@ ElifeConverter.Prototype = function() {
   };
 
 
-  // Example url to JPG: http://cdn.elifesciences.org/elife-articles/00768/svg/elife00768f001.jpg
+  // Example url to JPG: https://cdn.elifesciences.org/elife-articles/00768/svg/elife00768f001.jpg
   this.resolveURL = function(state, url) {
     // Use absolute URL
     if (url.match(/http:\/\//)) return url;
@@ -137,7 +137,7 @@ ElifeConverter.Prototype = function() {
       }
       
       return [
-        "http://publishing-cdn.elifesciences.org/",
+        "https://publishing-cdn.elifesciences.org/",
         state.doc.id,
         "/",
         url
@@ -151,7 +151,7 @@ ElifeConverter.Prototype = function() {
       return [baseURL, node.url].join('');
     } else {
       node.url = [
-        "http://publishing-cdn.elifesciences.org/",
+        "https://publishing-cdn.elifesciences.org/",
         state.doc.id,
         "/",
         node.url
@@ -219,7 +219,7 @@ ElifeConverter.Prototype = function() {
 
     if (pdfURI) {
       var pdfLink = [
-        "http://publishing-cdn.elifesciences.org/",
+        "https://publishing-cdn.elifesciences.org/",
         state.doc.id,
         "/",
         pdfURI ? pdfURI.getAttribute("xlink:href") : "#"
@@ -275,7 +275,7 @@ ElifeConverter.Prototype = function() {
       return [baseURL, node.url].join('');
     } else {
       node.url = [
-        "http://publishing-cdn.elifesciences.org/",
+        "https://publishing-cdn.elifesciences.org/",
         state.doc.id,
         "/",
         node.url
@@ -286,13 +286,13 @@ ElifeConverter.Prototype = function() {
   this.enhanceVideo = function(state, node, element) {
     var href = element.getAttribute("xlink:href").split(".");
     var name = href[0];
-    node.url = "http://api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file/"+name+".mp4";
-    node.url_ogv = "http://api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file//"+name+".ogv";
-    node.url_webm = "http://api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file//"+name+".webm";
-    node.poster = "http://api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file/"+name+".jpg";
+    node.url = "https://api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file/"+name+".mp4";
+    node.url_ogv = "https://api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file//"+name+".ogv";
+    node.url_webm = "https://api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file//"+name+".webm";
+    node.poster = "https://api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file/"+name+".jpg";
   };
 
-  // Example url to JPG: http://cdn.elifesciences.org/elife-articles/00768/svg/elife00768f001.jpg
+  // Example url to JPG: https://cdn.elifesciences.org/elife-articles/00768/svg/elife00768f001.jpg
   this.resolveURL = function(state, url) {
     // Use absolute URL
     if (url.match(/http:\/\//)) return url;
@@ -313,7 +313,7 @@ ElifeConverter.Prototype = function() {
       }
       
       return [
-        "http://publishing-cdn.elifesciences.org/",
+        "https://publishing-cdn.elifesciences.org/",
         state.doc.id,
         "/",
         url

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lens",
   "version": "2.1.0",
   "description": "A novel way of seeing content.",
-  "url": "http://github.com/elifesciences/lens",
+  "url": "https://github.com/elifesciences/lens",
   "keywords": [
     "digital documents",
     "linked-data",


### PR DESCRIPTION
eLife is going HTTPS only, this should change all references where available.

Unless I'm missing something, it seems that the built releases contain files not in this repository, so they will need to be updated too (eg Google Fonts, Font Awesome and MathJax in `index.html`).
