### PR TITLE
[math extension] add support for HTML fragments

### DIFF
--- a/extensions/math/math_converter.js
+++ b/extensions/math/math_converter.js
@@ -311,7 +311,7 @@ MathConverter.Prototype = function MathConverterPrototype() {
 
   this._getFormulaData = function(state, formulaElement, formulaId, inline) {
     var result = [];
-    var labels = {'tex' : {}, 'svg': {}, 'math': {}};
+    var labels = {'tex' : {}, 'svg': {}, 'html': {}, 'math': {}};
     var el = formulaElement;
     var alternatives = el.querySelector('alternatives');
     if (alternatives) el = alternatives;
@@ -330,6 +330,13 @@ MathConverter.Prototype = function MathConverterPrototype() {
           result.push({
             format: "svg",
             data: this.toHtml(child)
+          });
+          break;
+        case "textual-form":
+          labels.html = this._extractLabels(child);
+          result.push({
+            format: "html",
+            data: $(child).text()
           });
           break;
         case "mml:math":

--- a/extensions/math/nodes/formula/formula_view.js
+++ b/extensions/math/nodes/formula/formula_view.js
@@ -153,6 +153,14 @@ FormulaView.Prototype = function() {
               hasPreview = true;
             }
             break;
+            case "html":
+              // add only if no preview
+              if (!hasPreview) {
+                // don't use a preview element
+                this.$content.append($(data));
+                hasPreview = true;
+              }
+              break;
           default:
             console.error("Unknown formula format:", format);
         }


### PR DESCRIPTION
- the HTML fragment needs to be inside <textual-form> element
- the HTML fragment should be wrapped in CDATA tags
- the HTML fragment can include xlink data for the math panel
