### PR TITLE
Parse affiliation institution in two possible formats.

### DIFF
--- a/converter/lens_converter.js
+++ b/converter/lens_converter.js
@@ -620,10 +620,16 @@ NlmToLensConverter.Prototype = function() {
   this.affiliation = function(state, aff) {
     var doc = state.doc;
 
-    var institution = aff.querySelector("institution");
+    var department = aff.querySelector("institution[content-type=dept]");
+    if (department) {
+      var institution = aff.querySelector("institution:not([content-type=dept])");
+    } else {
+      var department = aff.querySelector("addr-line named-content[content-type=department]");
+      var institution = aff.querySelector("institution");
+    }
     var country = aff.querySelector("country");
     var label = aff.querySelector("label");
-    var department = aff.querySelector("addr-line named-content[content-type=department]");
+
     var city = aff.querySelector("addr-line named-content[content-type=city]");
     // TODO: there are a lot more elements which can have this.
     var specific_use = aff.getAttribute('specific-use');


### PR DESCRIPTION
eLife XML uses <institution> and <institution content-type="dept"> in <aff> differently.

Comments welcome - is this an acceptable way to handle two types of affiliation parsing?

Partially related to https://github.com/elifesciences/lens/issues/172, although all contributor affiliations on all eLife articles are incomplete (missing the institution name)
