### PR TITLE
Appendices and boxes

### DIFF
--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -325,11 +325,15 @@ ElifeConverter.Prototype = function() {
     switch(node.type) {
     // Boxes go into the figures view if these conditions are met
     // 1. box has a label (e.g. elife 00288)
+    // Disable it July 2017: no box has a label, and also cross reference links do not work if
+    //  they do try to link to the figures panel
+    /*
     case "box":
       if (node.label) {
         state.doc.show("figures", node.id);
       }
       break;
+    */
     default:
       __super__.showNode.apply(this, arguments);
     }

--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -325,8 +325,8 @@ ElifeConverter.Prototype = function() {
     switch(node.type) {
     // Boxes go into the figures view if these conditions are met
     // 1. box has a label (e.g. elife 00288)
-    // Disable it July 2017: no box has a label, and also cross reference links do not work if
-    //  they do try to link to the figures panel
+    // Disable it July 2017: cross reference links do not work if box reference
+    //  in the content panel tries to link to the figures panel
     /*
     case "box":
       if (node.label) {

--- a/converter/lens_converter.js
+++ b/converter/lens_converter.js
@@ -1329,11 +1329,13 @@ NlmToLensConverter.Prototype = function() {
     // Assuming that there are no nested <boxed-text> elements
     var childNodes = this.bodyNodes(state, util.dom.getChildren(box));
     var boxId = state.nextId("box");
+    // Optional heading label
+    var label = this.selectDirectChildren(box, "label")[0];
     var boxNode = {
       "type": "box",
       "id": boxId,
       "source_id": box.getAttribute("id"),
-      "label": "",
+      "label": label ? label.textContent : "",
       "children": _.pluck(childNodes, 'id')
     };
     doc.create(boxNode);

--- a/converter/lens_converter.js
+++ b/converter/lens_converter.js
@@ -2224,7 +2224,7 @@ NlmToLensConverter.Prototype = function() {
       "type" : "heading",
       "id" : headingId,
       "level" : 1,
-      "content" : title ? this.annotatedText(state, title, [headingId, "content"]) : "Appendix"
+      "content" : "Appendices"
     });
 
     this.show(state, [heading]);


### PR DESCRIPTION
The eLife converter was omitting boxes, original because they had no label. This will add them to the content panel rather than to the figures panel, because even if they get added to the figure panel, the crosslinking does not work yet.

eLife appendices will appear now too, since each appendix was wrapped in a ``boxed-text`` tag.

Parse the label from ``boxed-text`` tags.

Change the heading 1 of appencies to "Appendices" so it does not duplicate the title of the first appendix into the heading 2 value.