### PR TITLE
Tables improvements

### DIFF
--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -260,6 +260,20 @@ ElifeConverter.Prototype = function() {
     }
   };
 
+  this.enhanceTable = function(state, tableNode, tableWrap) {
+    tableNode.content = this.enhanceHTML(tableNode.content);
+  }
+
+  this.enhanceHTML = function(html) {
+    html = html.replace(/<(\/)?bold>/g, "<$1strong>");
+    html = html.replace(/<(\/)?italic>/g, "<$1em>");
+    // Table colours
+    html = html.replace(/<td style=\"([^"]+)\"([^>]*)>/g, "<td class=\"$1\"$2>");
+    // named-content span
+    html = html.replace(/<named-content content-type="([^"]+)"([^>]*)>([^<]*)<\/named-content>/g, "<span class=\"$1\"$2>$3</span>");
+    return html;
+  };
+
   this.enhanceVideo = function(state, node, element) {
     var href = element.getAttribute("xlink:href").split(".");
     var name = href[0];

--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -261,7 +261,29 @@ ElifeConverter.Prototype = function() {
   };
 
   this.enhanceTable = function(state, tableNode, tableWrap) {
+    this.mapCitations(state);
     tableNode.content = this.enhanceHTML(tableNode.content);
+  }
+
+  this.mapCitations = function (state)
+  {
+    // Map citation id to their citation reference for use in HTML replacements
+    this.citationCitationReferenceMap = [];
+    var citationSourceIdMap = [];
+    var doc = state.doc;
+    _.each(doc.nodes, function(node) {
+      if(node.type == "citation")
+      {
+        citationSourceIdMap[node.source_id] = node.id;
+      }
+    }.bind(this));
+    var annotations = state.annotations;
+    _.each(annotations, function(anno) {
+      if(anno.type == "citation_reference")
+      {
+        this.citationCitationReferenceMap[anno.target] = anno.id;
+      }
+    }.bind(this));
   }
 
   this.enhanceHTML = function(html) {
@@ -271,6 +293,19 @@ ElifeConverter.Prototype = function() {
     html = html.replace(/<td style=\"([^"]+)\"([^>]*)>/g, "<td class=\"$1\"$2>");
     // named-content span
     html = html.replace(/<named-content content-type="([^"]+)"([^>]*)>([^<]*)<\/named-content>/g, "<span class=\"$1\"$2>$3</span>");
+    // Hacky way to convert references inside tables
+    if(this.citationCitationReferenceMap)
+    {
+      var xref_pattern = /<xref ref-type="bibr" rid="([^"]+)">([^<]*)<\/xref>/g;
+      var matches = html.match(xref_pattern);
+      _.each(matches, function(match) {
+        var rid = match.replace(xref_pattern, "$1");
+        var content = match.replace(xref_pattern, "$2");
+        var citation_reference = this.citationCitationReferenceMap[rid];
+        var replace_tag = '<a href="" data-id="' + citation_reference + '" class="annotation citation_reference resource-reference">'+content+'</a>';
+        html = html.replace(match, replace_tag);
+      }.bind(this));
+    }
     return html;
   };
 

--- a/converter/lens_converter.js
+++ b/converter/lens_converter.js
@@ -1915,9 +1915,11 @@ NlmToLensConverter.Prototype = function() {
     };
 
     // Note: using a DOM div element to create HTML
-    var table = tableWrap.querySelector("table");
+    var table = tableWrap.querySelectorAll("table");
     if (table) {
-      tableNode.content = this.toHtml(table);
+      for (var i = 0; i < table.length; i++) {
+        tableNode.content += this.toHtml(table[i]);
+      }
     }
     this.extractTableCaption(state, tableNode, tableWrap);
 

--- a/styles/lens.css
+++ b/styles/lens.css
@@ -153,6 +153,50 @@ p:last-child { padding-bottom: 0; }
   color: gold;
 }
 
+.author-callout-style-a1 {
+  color: rgb(54, 107, 251); // Blue
+}
+
+.author-callout-style-a2 {
+  color: rgb(156, 39, 176); // Purple
+}
+
+.author-callout-style-a3 {
+  color: rgb(213, 0, 0); // Red
+}
+
+.author-callout-style-b1 {
+  background-color: rgb(144, 202, 249); // Blue
+}
+
+.author-callout-style-b2 {
+  background-color: rgb(197, 225, 165); // Green
+}
+
+.author-callout-style-b3 {
+  background-color: rgb(255, 183, 77); // Orange
+}
+
+.author-callout-style-b4 {
+  background-color: rgb(255, 241, 118); // Yellow
+}
+
+.author-callout-style-b5 {
+  background-color: rgb(158, 134, 201); // Purple
+}
+
+.author-callout-style-b6 {
+  background-color: rgb(229, 115, 115); // Red
+}
+
+.author-callout-style-b7 {
+  background-color: rgb(244, 143, 177); // Pink
+}
+
+.author-callout-style-b8 {
+  background-color: rgb(230, 230, 230); // Grey
+}
+
 .lens-article .content-node.cover .subjects a:not(:last-child):after {
   content: ', '
 }


### PR DESCRIPTION
In mainline Lens changes,
* Support for multiple tables per table-wrap
* Add more author callout styles which are used in coloured table cells

In eLife converter only
* HTML rewrites for basic tags: bold, italic, td class names, named-content
* A hacky HTML rewrite for citation references found inside table cells, but it seems to work so far