### PR TITLE
Skip rendering fig as a possible body node

### DIFF
--- a/converter/lens_converter.js
+++ b/converter/lens_converter.js
@@ -1311,9 +1311,10 @@ NlmToLensConverter.Prototype = function() {
   this._bodyNodes["comment"] = function(state, child) {
     return this.comment(state, child);
   };
-  this._bodyNodes["fig"] = function(state, child) {
-    return this.figure(state, child);
-  };
+  // Disable fig as a body node, otherwise the order of nodes in the Figures tab can be incorrect
+  //this._bodyNodes["fig"] = function(state, child) {
+  //  return this.figure(state, child);
+  //};
 
   // Overwirte in specific converter
   this.ignoredNode = function(/*state, node, type*/) {


### PR DESCRIPTION
Fixes https://github.com/elifesciences/lens/issues/210.

Do not render fig as a body node, otherwise it gets added first to the figures node list, and results in the Figures tab elements to be out of order, not showing Figure 1 first, e.g.

Testing with eLife article 26866 and 27215, this fixes the Figure tab order to display Figure 1 as the first node. It seems to have no side effects, so we'll try deploying it in a new bundle.