### PR TITLE
elife_converter, set assets urls from video_data.

### DIFF
--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -310,12 +310,17 @@ ElifeConverter.Prototype = function() {
   };
 
   this.enhanceVideo = function(state, node, element) {
+    var id = element.getAttribute("id");
     var href = element.getAttribute("xlink:href").split(".");
     var name = href[0];
-    node.url = "https://legacy--api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file/"+name+".mp4";
-    node.url_ogv = "https://legacy--api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file//"+name+".ogv";
-    node.url_webm = "https://legacy--api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file//"+name+".webm";
-    node.poster = "https://legacy--api.elifesciences.org/v2/articles/"+state.doc.id+"/media/file/"+name+".jpg";
+
+    // set attributes from previously populated data in video_data
+    if(typeof video_data !== 'undefined' && id in video_data) {
+      node.url = video_data[id]['mp4_href'];
+      node.url_ogv = video_data[id]['ogv_href'];
+      node.url_webm = video_data[id]['webm_href'];
+      node.poster = video_data[id]['jpg_href'];
+    }
   };
 
   // Example url to JPG: https://cdn.elifesciences.org/elife-articles/00768/svg/elife00768f001.jpg


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/4975

Instead of relying on an old API system that used http `301` redirects for eLife video asset files, the change here populates the video nodes with pre-populated values for the jpg, mp4, ogv and webm URLs.

This will correspond with a change to the `lens-elife` (https://github.com/elifesciences/lens-elife) repo that will have a helper to get video asset data from the eLife API prior to the Lens page building.

A known deficiency of this method is the `video_data` will not be changed if you drag-and-drop an XML file onto an existing eLife Lens page. Due to the desire to switch to the eLife API article data, this is a compromise, rather than trying to integrate an external `GET` request into standard Lens.

This should only affect eLife articles. The old URLs of eLife videos will eventually be unavailable when the legacy API helper is powered off. This may affect viewing of eLife videos in any project that displays eLife articles without the `video_data` populated.