### PR TITLE
Fix for focus link on some elife videos.

### DIFF
--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -13,6 +13,12 @@ ElifeConverter.Prototype = function() {
 
   var __super__ = LensConverter.prototype;
 
+  // Fix to focus on videos from left reading pane to the right figures pane
+  if (!("video" in __super__._refTypeMapping))
+  {
+    __super__._refTypeMapping["video"] = "figure_reference";
+  }
+
   this.test = function(xmlDoc, documentUrl) {
 		var publisherName = xmlDoc.querySelector("publisher-name").textContent;
     return publisherName === "eLife Sciences Publications, Ltd";


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/3485, also observed in https://github.com/elifesciences/issues/issues/109.

For some, not all, eLife videos, the "focus" button doesn't work, and similarly if you click the reference to e.g. `Video 1` in the left side pane, it does not focus on the video in the right pane.

An example article where this was observed: https://lens.elifesciences.org/32794/

I had a potential fix where the `_refTypeMapping` dictionary is altered in `elife_converter.js`. It seems to still work, and it should only affect eLife content for the better.