### PR TITLE
Fix figures panel not showing when none of the figures has a paragraph.

### DIFF
--- a/reader/panels/container_panel_view.js
+++ b/reader/panels/container_panel_view.js
@@ -33,7 +33,7 @@ ContainerPanelView.Prototype = function() {
 
   this.render = function() {
     // Hide the whole tab if there is no content
-    if (this.getContainer().hasContent()) {
+    if (this.getContainer().hasContent(this.config.type)) {
       this.surface.render();
       this.scrollbar.render();
     } else {

--- a/reader/panels/container_panel_view.js
+++ b/reader/panels/container_panel_view.js
@@ -33,12 +33,12 @@ ContainerPanelView.Prototype = function() {
 
   this.render = function() {
     // Hide the whole tab if there is no content
-    if (this.getContainer().getLength() === 0) {
-      this.hideToggle();
-      this.hide();
-    } else {
+    if (this.getContainer().hasContent()) {
       this.surface.render();
       this.scrollbar.render();
+    } else {
+      this.hideToggle();
+      this.hide();
     }
     return this;
   };

--- a/substance/document/container.js
+++ b/substance/document/container.js
@@ -136,6 +136,10 @@ Container.Prototype = function() {
     return this.listView.length;
   };
 
+  this.hasContent = function(panelType) {
+    return this.listView.length > 0 || (panelType === 'resource' && this.treeView.length > 0);
+  };
+
   // Returns true if there is another node after a given position.
   // --------
   //


### PR DESCRIPTION
Figures panel doesn't show when the figures hasn't caption or the captions hasn't a paragraph. So when the panel is of "resource" type it should check if the treeView has nodes.