### PR TITLE
Change decision letter parsing for eLife articles.

### DIFF
--- a/converter/elife_converter.js
+++ b/converter/elife_converter.js
@@ -40,42 +40,23 @@ ElifeConverter.Prototype = function() {
     var doc = state.doc;
     var heading, body;
 
-    // Decision letter (if available)
+    // Decision letter and author response sub articles (if available)
     // -----------
+    var subArticles = article.querySelectorAll("sub-article");
+    _.each(subArticles, function(subArticle) {
+        var subArticleTitle = subArticle.querySelector("title-group article-title").textContent;
+        heading = {
+          id: state.nextId("heading"),
+          type: "heading",
+          level: 1,
+          content: subArticleTitle
+        };
+        doc.create(heading);
+        nodes.push(heading);
 
-    var articleCommentary = article.querySelector("#SA1");
-    if (articleCommentary) {
-      heading = {
-        id: state.nextId("heading"),
-        type: "heading",
-        level: 1,
-        content: "Decision letter"
-      };
-      doc.create(heading);
-      nodes.push(heading);
-
-      body = articleCommentary.querySelector("body");
-      nodes = nodes.concat(this.bodyNodes(state, util.dom.getChildren(body)));
-    }
-
-    // Author response
-    // -----------
-
-    var authorResponse = article.querySelector("#SA2");
-    if (authorResponse) {
-
-      heading = {
-        id: state.nextId("heading"),
-        type: "heading",
-        level: 1,
-        content: "Author response"
-      };
-      doc.create(heading);
-      nodes.push(heading);
-
-      body = authorResponse.querySelector("body");
-      nodes = nodes.concat(this.bodyNodes(state, util.dom.getChildren(body)));
-    }
+        body = subArticle.querySelector("body");
+        nodes = nodes.concat(this.bodyNodes(state, util.dom.getChildren(body)));
+    }.bind(this));
 
     // Show them off
     // ----------


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6463

A short summary of the bug to be fixed in this PR, eLife Decision letter and Author response `<sub-article>` peer review articles previously had `@id` attribute values of `SA1` and `SA2`, and these were used in the query selectors in Lens' `elife_converter.js` to find them.

In more recent eLife articles the `@id` values have gone lowercase, `sa1` and `sa2`, which causes them to not display on Lens.

Initially we were planning to change the logic to look at the `@article-type` of the `<sub-article>` tag to determine whether the node should be assigned a heading of "Decision letter" or "Author response". After some consideration of how the `<sub-article>` tags could be processed in a loop, it looked to be easier to take the Lens node heading value from the `<article-title>` tag of the `<sub-article>`.

This should only affect eLife articles since we are only editing the `converter/elife_converter.js` file. The logic here should also be backwards compatible for all eLife articles based on the previously published article data I checked. It also does not cause any errors if there are no `<sub-article>` tags in the article XML.

