### PR TITLE
Bump underscore from 1.8.3 to 1.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/elifesciences/lens.git"
   },
   "dependencies": {
-    "underscore": "1.8.3"
+    "underscore": "1.12.1"
   },
   
   "engines": {


### PR DESCRIPTION
In response to a dependabot vulnerability alert, bumping the version of `underscore` seems to have no adverse impact on `lens` or a library based on it such as `lens-elife`.